### PR TITLE
add problems

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,7 @@
 import { Problem } from '@/problem/problem'
 import { Git } from '@/git/git'
+import { Directory } from './git/fileStructure'
+import { PushRejectedError } from './git/gitTypes'
 
 export const cli = (command: string, problem:Problem) => {
   
@@ -62,13 +64,13 @@ export const cli = (command: string, problem:Problem) => {
           resultString = '현재 이 디렉토리는 git 저장소가 아닙니다.'
           return
         }
-        if (problem.git.getUserConfig({type:'email'}) === '') {
-          resultString = `commit 작성자가 누군지 설정되어 있지 않습니다. 
-          git config user.name 'your name'
-          git config user.email your@email.com
-          으로 먼저 설정한다음 commit하세요.`
-          return
-        }
+        // if (problem.git.getUserConfig({type:'email'}) === '') {
+        //   resultString = `commit 작성자가 누군지 설정되어 있지 않습니다. 
+        //   git config user.name 'your name'
+        //   git config user.email your@email.com
+        //   으로 먼저 설정한다음 commit하세요.`
+        //   return
+        // }
         if (option !== '-m') {
           resultString = `잘못된 commit 옵션입니다. 'git commit -m ${message ?? '메세지'}'를 쓰려고 하셨나요?`
           return
@@ -116,6 +118,68 @@ export const cli = (command: string, problem:Problem) => {
         const status = problem.git.status()
         resultString = JSON.stringify(status, null, 4)
       },
+
+      remote(third?:string, remoteName?:string, remoteUrl?:string){
+        if (!problem.git) {
+          resultString = '현재 이 디렉토리는 git 저장소가 아닙니다.'
+          return
+        }
+        if (third === undefined || remoteName=== undefined || remoteUrl===undefined){
+          resultString = `'$ git remote add origin 원격저장소주소'의 올바른 사용이 아닙니다.`
+          return
+        }
+        if (third === 'add') {
+          try{
+            const remote = new Git(new Directory(remoteUrl))
+            problem.git.addRemote(remoteName, remote)
+          }catch{
+            resultString =  `이미 이 저장소에 ${remoteName}이 존재하거나, ${remoteUrl} 주소가 잘못되었습니다.`
+          }
+        } else {
+          resultString = '지원하지 않는 명령어 입니다.'
+        }
+      },
+
+      push(remoteName?:string, branchName?:string) {
+        if (!problem.git) {
+          resultString = '현재 이 디렉토리는 git 저장소가 아닙니다.'
+          return
+        }
+        if (remoteName===undefined || branchName===undefined){
+          resultString = `'$ git push origin master'처럼 올바르게 사용해주세요.`
+          return
+        }
+        try {
+          problem.git.push(remoteName, branchName)
+          resultString = '어떻게 push 되었는지 알려드리고 싶지만, 아직은 마음만 있어요.'
+        } catch (error) {
+          if (error instanceof PushRejectedError) {
+            resultString = `${remoteName}의 ${branchName}이 로컬 저장소보다 앞서 있어서 push할 수 없습니다.`
+            return
+          }else{
+            resultString = `${remoteName}이나 ${branchName}이 잘못되었어요.`
+            return
+          }
+        }
+      },
+
+      pull(remoteName?: string, branchName?: string) {
+        if (!problem.git) {
+          resultString = '현재 이 디렉토리는 git 저장소가 아닙니다.'
+          return
+        }
+        if (remoteName===undefined || branchName===undefined){
+          resultString = `'$ git pull origin master'처럼 올바르게 사용해주세요.`
+          return
+        }
+        try {
+          problem.git.pull(remoteName, branchName)
+          // pull하다가 conflict 날 경우에는 추가로 commit 해야하는데, 그거는 일단 보류
+          resultString = '어떻게 pull 되었는지 알려드리고 싶지만, 아직은 마음만 있어요.'
+        } catch (error) {
+          resultString = `${remoteName}이나 ${branchName}을 다시 확인해주세요.`
+        }
+      }
     }
     
     subCommands[secondCommand](...restCommand)

--- a/src/components/molecules/ProblemNavigator.vue
+++ b/src/components/molecules/ProblemNavigator.vue
@@ -12,7 +12,7 @@
         class='stages__title'
         @click="showStageList"
       >
-        {{ index }} of 12
+        {{ index }} of {{ lastProblemIndex }}
       </Title>
       <div>
         <!-- ...dropdown... -->

--- a/src/components/organisms/ProblemInstruction.vue
+++ b/src/components/organisms/ProblemInstruction.vue
@@ -6,6 +6,10 @@
     <Card class="problem__instruction-content">
       <p v-html="wrapCodesInProblemContent"></p>
     </Card>
+    <br>
+    <Card class="problem__instruction-content">
+      <p v-html="wrapCodesInProblemExplanation"></p>
+    </Card>
   </div>
 </template>
 
@@ -17,7 +21,7 @@ import { Title, Card } from '@/components'
 export default defineComponent({
   components: {
     Title,
-    Card
+    Card,
   },
   props: {
     problem: {
@@ -28,22 +32,43 @@ export default defineComponent({
   setup(props) {
     const { problem } = toRefs(props)
 
-    const wrapCodesInProblemContent = computed(() => {
-      let problemContent = problem.value.content
+    const wrapCodesInProblem = (paragraph: string | undefined) => {
+      if (!paragraph) {
+        return ''
+      }
       const pattern = new RegExp('\\*\\$.+?\\*', 'g')
-      const matchList = problemContent?.match(pattern)
-      
-      let result = problemContent
+      const matchList = paragraph?.match(pattern)
+
+      let result = paragraph
       matchList?.forEach((code) => {
-        const codeAsteriskRemoved = code.slice(1, code.length-1)
+        const codeAsteriskRemoved = code.slice(1, code.length - 1)
         const codeDecorated = `<code class="problem__content-code">${codeAsteriskRemoved}</code>`
         result = result?.replace(code, codeDecorated)
       })
+      result = result.replace(/\n/g, '<br>')
+
+      const boldPattern = /\*.*?\*/g
+      const boldMatchList = result.match(boldPattern)
+      boldMatchList?.forEach((bold)=> {
+        const asteriskRemoved = bold.slice(1, bold.length -1)
+        const boldDecorated = `<span style="font-weight:900;color:#ff6103">${asteriskRemoved}</span>`
+        result = result.replace(bold, boldDecorated)
+      })
+
       return result
-    })
+    }
+
+    const wrapCodesInProblemContent = computed(() =>
+      wrapCodesInProblem(problem.value.content)
+    )
+
+    const wrapCodesInProblemExplanation = computed(() =>
+      wrapCodesInProblem(problem.value.explanation)
+    )
 
     return {
       wrapCodesInProblemContent,
+      wrapCodesInProblemExplanation,
     }
   },
 })

--- a/src/problem/index.ts
+++ b/src/problem/index.ts
@@ -4,6 +4,11 @@ import {
   problem2BasicAdd,
   problem3BasicCommit,
   problem4UserConfig,
+  problem5AddAdvanced,
+  problem6AddCommitPractice,
+  problem7Remote,
+  problem8PushToRemote,
+  problem9PullFromRemote,
 } from './problems'
 
 const problems = [
@@ -11,6 +16,11 @@ const problems = [
   problem2BasicAdd,
   problem3BasicCommit,
   problem4UserConfig,
+  problem5AddAdvanced,
+  problem6AddCommitPractice,
+  problem7Remote,
+  problem8PushToRemote,
+  problem9PullFromRemote,
 ]
 
 export { Problem, problems }

--- a/src/problem/problem.ts
+++ b/src/problem/problem.ts
@@ -15,6 +15,8 @@ interface answer extends Function {
 export class Problem {
   /** @property 문제 제목 */
   title: string
+  /** @property 문제 해결을 위한 이론 설명 */
+  explanation?: string
   /** @property 문제 내용 */
   content?: string
   /** @property 문제의 환경이 되는 디렉토리 */

--- a/src/problem/problems/index.ts
+++ b/src/problem/problems/index.ts
@@ -2,10 +2,20 @@ import { problem1Init } from './problem1'
 import { problem2BasicAdd } from './problem2'
 import { problem3BasicCommit } from './problem3'
 import { problem4UserConfig } from './problem4'
+import { problem5AddAdvanced } from './problem5'
+import { problem6AddCommitPractice } from "./problem6";
+import { problem7Remote } from "./problem7";
+import { problem8PushToRemote } from "./problem8";
+import { problem9PullFromRemote } from "./problem9";
 
 export {
   problem1Init,
   problem2BasicAdd,
   problem3BasicCommit,
   problem4UserConfig,
+  problem5AddAdvanced,
+  problem6AddCommitPractice,
+  problem7Remote,
+  problem8PushToRemote,
+  problem9PullFromRemote,
 }

--- a/src/problem/problems/problem1.ts
+++ b/src/problem/problems/problem1.ts
@@ -5,8 +5,11 @@ export const problem1Init = new Problem('Git 초기화하기')
 
 // 사실 문제 목적이랑은 상관없는 그냥 파일
 new PlainFile('README.txt', problem1Init.refDirectory)
-problem1Init.content = `지금부터 이 디렉토리를 git으로 관리하려고 합니다. 
-아래의 명령어를 참고하여 문제를 해결하세요!`
+problem1Init.content = `지금부터 이 디렉토리를 git 저장소로 관리하려고 합니다. 
+*$ git init* 을 통해 이 디렉토리를 git 저장소로 초기화 해보세요!`
+problem1Init.explanation = `git은 디렉토리 내부의 변경 이력을 관리하는 일을 합니다.
+변경 이력을 관리하면, 저장소가 어떻게 변해왔는지 확인하거나 특정 시점의 파일로 돌아가는 일 등을 할 수 있습니다.
+또, 여러명이 같은 파일로 작업할 때 무엇이 바뀌었는지 확인하기도 좋습니다.`
 problem1Init.setAnswer((refDirectory, git)=>{
   // 만약 git이 problem1에 설정되어있고, 그 refDirectory가 문제의 디렉토리와 같다면?
   // git init을 했다고 판단할 수 있음

--- a/src/problem/problems/problem2.ts
+++ b/src/problem/problems/problem2.ts
@@ -2,28 +2,22 @@ import { Problem } from "@/problem/problem"
 import { PlainFile } from "@/git/fileStructure"
 
 export const problem2BasicAdd = new Problem('staging 하기')
-problem2BasicAdd.content = `이 디렉토리는 git으로 관리되고 있습니다.
-디렉토리의 README.txt를 staging area에 올리려합니다.
-*$ git status*를 통해 현재 상태를 확인해보세요.
-*$ git add README.txt*를 통해 README.txt를 staging 해보세요.`
-const fileReadme = new PlainFile('README.txt', problem2BasicAdd.refDirectory)
+problem2BasicAdd.content = `이 git 저장소에 두 파일이 새롭게 추가되었습니다. 추가된 파일 중, *staging.txt* 를 staging area에 추가해주세요.`
+problem2BasicAdd.explanation = `git으로 변경 이력을 남기려면, 먼저 어떤 변경사항을 기록할지를 선택해야 합니다. 선택된 변경사항은 staging area라는 곳에 존재하게 되고, 나중에 staging area에 존재하는 변경사항을 기록하게 됩니다. 이 문제에서는 먼저 변경사항을 staging area에 추가합니다.
+*$ git status* 를 입력하면 저장소에 현재 어떤 변경점이 있는지를 확인할 수 있습니다. 
+*추적하지 않는 파일* 에 나타나는 파일들은 아직 git에서 관리한 적이 없는, 새로 등장한 파일들입니다.
+*$ git add 파일이름* 을 통해 원하는 파일을 staging area에 추가할 수 있습니다. *staging.txt* 만 staging area에 추가하고, 다시 *$ git status* 를 통해 어떤 변화가 있는지 확인해보세요.
+*커밋할 변경 사항*에 나타나는 파일들은 staging area에 추가되어서 기록할 준비가 된 파일들입니다.`
 
+const staging = new PlainFile('staging.txt', problem2BasicAdd.refDirectory)
+const unstaging = new PlainFile('unstaging.txt', problem2BasicAdd.refDirectory)
 // 문제에 맞게 git add 만 하면 되도록 미리 git init해둠
 problem2BasicAdd.setGit()
 problem2BasicAdd.setBase()
 problem2BasicAdd.setAnswer((_, git)=>{
   if (git) {
     // index(staging area)에 README.txt가 존재한다면 add한 것으로 판단!
-    return git.isExistAtIndex(fileReadme)
+    return git.isExistAtIndex(staging) && !git.isExistAtIndex(unstaging)
   }
   return false
 })
-
-
-
-
-
-
-
-
-

--- a/src/problem/problems/problem3.ts
+++ b/src/problem/problems/problem3.ts
@@ -2,17 +2,20 @@ import { Problem } from "@/problem/problem"
 import { PlainFile } from "@/git/fileStructure"
 
 export const problem3BasicCommit = new Problem('commit 남기기')
-problem3BasicCommit.content = 
-`현재 디렉토리의 README.txt가 staging area에 추가되어있습니다.
-*$ git status*를 통해 현재 상태를 확인해보세요.
-*$ git commit -m '커밋 메시지'* 통해서 메세지를 남길 수 있습니다.`
-const readme = new PlainFile('README.txt', problem3BasicCommit.refDirectory)
+problem3BasicCommit.explanation = `staging area에 추가된 변경사항을 기록하는 일, 혹은 그 기록을 commit 이라고 합니다.
+방금 문제에서 staging area에 추가한 *staging.txt* 를 commit 해보겠습니다.
+  먼저 *$ git status* 를 통해 *staging.txt* 가 staging area에 추가되어있는 모습을 확인하세요.
+*$ git commit -m '메세지 내용'* 을 통해서 적당한 메세지와 함께 commit을 남길 수 있습니다.
+commit 후에 다시 *$ git status* 를 통해 상태를 확인해보세요. *staging.txt* 의 변경사항은 기록되었기 때문에 status에 출력되지 않는 것을 확인하실 수 있습니다.`
+problem3BasicCommit.content = `이 저장소의 staging area에 *staging.txt* 가 추가되어 있습니다. 해당 변경사항만을 commit하세요.`
+const staging = new PlainFile('staging.txt', problem3BasicCommit.refDirectory)
+const unstaging = new PlainFile('unstaging.txt', problem3BasicCommit.refDirectory)
 problem3BasicCommit.setGit()
-problem3BasicCommit.git!.add()
+problem3BasicCommit.git!.add([staging.filename])
 problem3BasicCommit.setBase()
 problem3BasicCommit.setAnswer((_, git)=>{
   if (git) {
-    return git.isExistAtRecentCommit(readme)
+    return git.isExistAtRecentCommit(staging) && !git.isExistAtRecentCommit(unstaging)
   }
   return false
 })

--- a/src/problem/problems/problem4.ts
+++ b/src/problem/problems/problem4.ts
@@ -2,22 +2,34 @@ import { Problem } from "@/problem/problem"
 import { PlainFile } from "@/git/fileStructure"
 
 export const problem4UserConfig = new Problem('user config 등록하기')
-problem4UserConfig.content = 
-`commit에는 미리 설정한 작성자 정보가 함께 기록됩니다.
-*$ git config user.name '이름'* 으로 commit 작성자의 이름을,
-*$ git config user.email '이메일주소'* 으로 이메일주소를 설정할 수 있습니다.
-위 명령어는 이 저장소에만 적용되는 설정입니다..
-만약 컴퓨터의 모든 저장소에 적용되는 설정을 하려면
-*$ git config --global user.name '이름'* 처럼 각 명령어에 --global 키워드를 붙여주세요.
-user config 설정 이후 README.txt를 commit하여 작성자 정보를 확인하세요.
-*$ git add 파일이름* 과
-*$ git commit -m '메세지'* 를 활용하세요.`
-const README = new PlainFile('README.txt', problem4UserConfig.refDirectory)
+problem4UserConfig.content = `이 저장소에 새로 추가된 *with_user_config.txt* 라는 파일을
+- 이름: *bing*
+- 이메일주소: *bing@bing.com*
+의 작성자 정보를 가지도록 commit을 남겨주세요. commit을 남기기 전에 작성자 정보 설정이 선행되어야 합니다.`
+problem4UserConfig.explanation = `commit에는 commit을 남긴 작성자 정보가 함께 기록됩니다. 저장소에 한 번 작성자 정보를 설정하면, 이후의 commit에는 해당 작성자 정보가 항상 남게 됩니다. 작성자 정보를 설정하고, commit을 남겨보겠습니다!
+*$ git config user.name '작성자 이름'* 으로 작성자 이름을, 
+*$ git config user.email '이메일주소'* 으로 이메일 주소를 설정할 수 있습니다.
+설정한 이름과 이메일 주소를 확인하고 싶다면 맨 뒤의 인자를 빼고
+*$ git config user.name*
+*$ git config user.email*
+으로 확인할 수 있습니다.
+
+만약 컴퓨터의 모든 git 저장소에서 같은 작성자 정보를 유지하고 싶다면 —global 키워드를 붙여 아래와 같이 사용할 수 있습니다.
+*$ git config --global user.name '작성자 이름'*
+*$ git config --global user.email '이메일주소'*
+따옴표는 보통 중간에 공백이 포함되는 경우에 사용하며, 공백이 없다면 아래 예시와 같이 작성할 수 있습니다.
+예시) *$ git config user.name Tom*
+
+추가로 문제 해결을 위해서
+*$ git add 파일이름*
+*$ git commit -m '커밋 메세지'*
+를 참고하세요.`
+const withUserConfig = new PlainFile('with_user_config.txt', problem4UserConfig.refDirectory)
 problem4UserConfig.setGit()
 problem4UserConfig.setBase()
 problem4UserConfig.setAnswer((_, git)=>{
   if (git) {
-    const isUserConfigExists = git.config.user.email && git.config.user.name
+    const isUserConfigExists = git.config.user.email === 'bing@bing.com' && git.config.user.name === 'bing'
     const recentCommit = git.getMostRecentCommit()
     const isEmailMatched = recentCommit?.author.email === git.config.user.email
     const isNameMatched = recentCommit?.author.name === git.config.user.name

--- a/src/problem/problems/problem5.ts
+++ b/src/problem/problems/problem5.ts
@@ -1,0 +1,27 @@
+import { Problem } from "@/problem/problem"
+import { PlainFile } from "@/git/fileStructure"
+
+export const problem5AddAdvanced = new Problem('한번에 여러 파일 staging하기')
+
+problem5AddAdvanced.content = `지금 이 저장소에 발생한 모든 변경사항을 staging area에 추가해주세요.`
+problem5AddAdvanced.explanation = `한번에 여러 변경사항을 staging area에 추가하는 방법을 알아보겠습니다.
+*$ git add 첫번째파일이름 두번째파일이름 ...* 으로 여러 변경사항을 추가할 수 있습니다.
+또는, *$ git add .* 으로 현재 위치에서 발생한 모든 변경사항을 추가할 수 있습니다.
+먼저 *$ git status* 를 통해 발생한 변경사항을 확인해보세요.`
+
+const modified = new PlainFile('modified.txt', problem5AddAdvanced.refDirectory)
+const deleted = new PlainFile('deleted.txt', problem5AddAdvanced.refDirectory)
+const untracked1 = new PlainFile('untracked1.txt', problem5AddAdvanced.refDirectory)
+const untracked2 = new PlainFile('untracked2.txt', problem5AddAdvanced.refDirectory)
+problem5AddAdvanced.setGit()
+problem5AddAdvanced.git?.add([modified.filename, deleted.filename])
+problem5AddAdvanced.git?.commit('initial commit')
+modified.content = '수정된 내용'
+problem5AddAdvanced.refDirectory.delete(deleted)
+problem5AddAdvanced.setBase()
+problem5AddAdvanced.setAnswer((_, git)=>{
+  if(git){
+    return git.isExistAtIndex([modified, untracked1, untracked2]) && !git.isExistAtIndex(deleted)
+  }
+  return false
+})

--- a/src/problem/problems/problem6.ts
+++ b/src/problem/problems/problem6.ts
@@ -1,0 +1,32 @@
+import { Problem } from "@/problem/problem"
+import { PlainFile } from "@/git/fileStructure"
+
+export const problem6AddCommitPractice = new Problem('add, commit 실습하기')
+
+problem6AddCommitPractice.content = `저장소에 존재하는 네 파일 중, 하나의 파일은 이전 commit과 비교하여 파일 내용이 수정되었고, 나머지 파일은 새로 생성되었습니다. 먼저 수정된 파일을 commit하고, 다음 commit에는 나머지 파일들을 모두 추가해주세요.
+*$ git status* 를 통해 문제해결에 도움을 얻을 수 있습니다.`
+problem6AddCommitPractice.explanation = `아래의 명령어를 참고하세요.
+*$ git add 파일이름*
+*$ git commit -m '커밋 메세지'*
+어떤 파일이 수정되었는지를 확인하기 위해서 *$ git status* 를 활용하세요.`
+
+const modified = new PlainFile('modified.txt', problem6AddCommitPractice.refDirectory)
+const untracked1 = new PlainFile('untracked1.txt', problem6AddCommitPractice.refDirectory)
+const untracked2 = new PlainFile('untracked2.txt', problem6AddCommitPractice.refDirectory)
+const untracked3 = new PlainFile('untracked3.txt', problem6AddCommitPractice.refDirectory)
+problem6AddCommitPractice.setGit()
+problem6AddCommitPractice.git?.add([modified.filename])
+problem6AddCommitPractice.git?.commit('add modified')
+modified.content = '수정된 내용'
+problem6AddCommitPractice.setBase()
+problem6AddCommitPractice.setAnswer((_, git)=>{
+  if(git){
+    const headCommitHash = git.branches[git.head]
+    const isAllCommitted = git.isExistAtCommit([modified, untracked1, untracked2, untracked3], headCommitHash)
+    const parentCommitHash = git.getMostRecentCommit()!.parent[0]
+    const isModifiedCommittedFirst = git.isExistAtCommit(modified, parentCommitHash)
+    return isAllCommitted && isModifiedCommittedFirst
+  }
+  return false
+})
+

--- a/src/problem/problems/problem7.ts
+++ b/src/problem/problems/problem7.ts
@@ -1,0 +1,26 @@
+import { Problem } from '@/problem/problem'
+import { PlainFile } from '@/git/fileStructure'
+import { Git } from '@/git/git'
+
+export const problem7Remote = new Problem('원격 저장소 등록하기')
+
+problem7Remote.content = `이 저장소에 *origin* 이라는 별명으로 *https://github.com/bingbing-ba/gitcabinet.git* 의 원격 저장소를 등록해주세요! 원격 저장소는 이미 만들어진 상태라고 가정합니다.`
+problem7Remote.explanation = `원격 저장소는 다른 곳에 존재하는 백업 형태의 저장소를 말합니다. 
+보통 원격 저장소는 직접 다른 컴퓨터에 만들기보단, 이미 제공되는 서비스를 통해 만듭니다. 주로 github과 gitlab을 많이 사용합니다. github이나 gitlab 홈페이지에 들어가보면, 어렵지 않게 원격 저장소를 만드실 수 있습니다. 원격 저장소를 만들고나면 해당 원격 저장소의 주소가 생성되는데, 이 주소를 내 컴퓨터의 저장소와 연결하여 사용할 수 있습니다.
+
+이 문제에서는 이미 원격 저장소가 만들어진 상태라 생각하고, 연결하는 일만 해보겠습니다.
+만들어진 원격 저장소의 주소는 *https://github.com/bingbing-ba/gitcabinet.git* 입니다.
+*$ git remote add origin* 원격저장소주소 를 통해 이 저장소에 원격 저장소의 주소를 등록할 수 있습니다. 중간의 *origin*은 원격 저장소 주소를 간편하게 쓰기 위한 별명이라고 생각하면 됩니다. 이 별명은 *origin* 이 아니라 다르게도 사용할 수 있지만, 관례적으로 *origin* 으로 사용합니다.`
+
+problem7Remote.setGit()
+new PlainFile('a.txt', problem7Remote.refDirectory)
+new PlainFile('b.txt', problem7Remote.refDirectory)
+problem7Remote.git?.add()
+problem7Remote.git?.commit('initial commit')
+problem7Remote.setBase()
+problem7Remote.setAnswer((_, git) => {
+  if (git) {
+    return git.config.remote['origin'] instanceof Git
+  }
+  return false
+})

--- a/src/problem/problems/problem8.ts
+++ b/src/problem/problems/problem8.ts
@@ -1,0 +1,30 @@
+import { Problem } from '@/problem/problem'
+import { Directory, PlainFile } from '@/git/fileStructure'
+import { Git } from '@/git/git'
+import { isEqual } from 'lodash'
+
+export const problem8PushToRemote = new Problem('원격 저장소에 push하기')
+
+problem8PushToRemote.content = `현재 이 저장소에는 두 개의 commit이 존재합니다. 원격 저장소 *origin* 에는 아무런 commit도 존재하지 않습니다. 두 개의 commit을 원격 저장소에 *push*하세요!`
+problem8PushToRemote.explanation = `내 컴퓨터에 쌓인 commit을 원격 저장소에 업로드 하는 것을 *push* 라고 합니다.
+명령어 *$ git push origin master* 를 통해서 push가 가능합니다. 
+여기서 *origin* 은 이전 문제에서 등록했던 원격 저장소 주소의 별명입니다. 만약  *origin* 이 어떤 주소를 가리키고 있는지 확인하고 싶다면, 명령어 *$ git remote -v* 를 통해서 알 수 있습니다. 물론 *push* 할 때마다 확인하실 필요는 없고, 필요할 때만 사용하시면 됩니다.
+뒤의 *master* 는 *master* 라는 브랜치를 의미하는데, 지금 시점에서는 *master* 브랜치를 내 컴퓨터의 commit들로 해석하시면 됩니다. 엄밀하게 보면 틀린 말이지만, 여기서는 넘어가도 괜찮습니다. 이후 브랜치를 다루는 문제에서 다시 자세히 설명하겠습니다.
+명령어를 해석하면, 내 컴퓨터의 commit을 *origin*이라는 원격 저장소에 업로드하겠다는 의미가 됩니다.`
+
+problem8PushToRemote.setGit()
+const a = new PlainFile('a.txt', problem8PushToRemote.refDirectory)
+const b = new PlainFile('b.txt', problem8PushToRemote.refDirectory)
+problem8PushToRemote.git?.add([a.filename])
+problem8PushToRemote.git?.commit('add a.txt')
+problem8PushToRemote.git?.add([b.filename])
+problem8PushToRemote.git?.commit('add b.txt')
+const origin = new Git(new Directory('origin@origin.com'))
+problem8PushToRemote.git?.addRemote('origin', origin)
+problem8PushToRemote.setBase()
+problem8PushToRemote.setAnswer((_, git)=>{
+  if(git){
+    return isEqual(git.config.remote['origin'].commits, git.commits) 
+  }
+  return false
+})

--- a/src/problem/problems/problem9.ts
+++ b/src/problem/problems/problem9.ts
@@ -1,0 +1,34 @@
+import { Problem } from '@/problem/problem'
+import { Directory, PlainFile } from '@/git/fileStructure'
+import { Git } from '@/git/git'
+
+export const problem9PullFromRemote = new Problem('원격 저장소에서 pull하기')
+
+problem9PullFromRemote.content = `현재 이 저장소에는 *README.md* 를 기록한 하나의 commit 만이 존재합니다. 원격 저장소에는 해당 commit 이후에 *pull.txt* 를 기록한 또다른 commit이 존재합니다. 즉 두 개의 commit이 존재합니다.
+원격 저장소의 commit을 이 저장소로 pull 해주세요!
+해당 원격 저장소는 이 저장소에 *origin* 으로 등록되어 있습니다.`
+problem9PullFromRemote.explanation = `원격 저장소의 내용을 내 컴퓨터의 저장소에 내려받는 것을 *pull* 이라고 합니다. *clone* 과 다른 점은, *clone* 은 내 컴퓨터에 저장소가 존재하지 않고, *pull* 은 저장소가 존재한다는 점 입니다. 덧붙이면,
+*pull*은 이미 내 컴퓨터에 git 저장소가 존재하는데, 원격 저장소의 내용으로 내 저장소를 업데이트 하고싶을 때 사용합니다.
+*clone*은 내 컴퓨터에 저장소가 존재하지 않고, 새로 저장소를 만들어 원격 저장소의 내용을 가져오고 싶을 때 사용합니다. 
+명령어 *$ git pull origin master* 로 *pull* 하실 수 있습니다.
+여기서 *origin* 은 미리 등록해둔 원격 저장소의 주소입니다.
+*master* 는 *master* 라는 브랜치인데, 여기서는 '내 컴퓨터로' 정도로 해석해도 충분합니다. 이후에 브랜치 문제에서 자세히 설명하겠습니다.
+그래서 위의 명령어는 "원격 저장소 *origin* 의 내용을 내 컴퓨터로 가져와 업데이트 하겠다." 정도로 해석가능합니다.`
+
+problem9PullFromRemote.setGit()
+const README = new PlainFile('README.md', problem9PullFromRemote.refDirectory)
+problem9PullFromRemote.git?.add()
+problem9PullFromRemote.git?.commit('initial commit')
+const origin = new Git(new Directory('origin'))
+problem9PullFromRemote.git?.addRemote('origin', origin)
+problem9PullFromRemote.git?.push('origin', 'master')
+const pull = new PlainFile('pull.txt', origin.refDirectory)
+origin.add()
+const {hash} = origin.commit('add pull.txt')
+problem9PullFromRemote.setBase()
+problem9PullFromRemote.setAnswer((_, git)=>{
+  if(git){
+    return git.branches[git.head] === hash
+  }
+  return false
+})


### PR DESCRIPTION
# 문제 추가와 해당 문제에 필요한 기능 추가
## 문제 추가
노션에서 clone을 제외한 모든 문제를 추가해 두었습니다. 총 9문제네요.

## cli 기능 추가
- commit: user config 설정 없이도 commit 가능하도록 변경해두었습니다.
- remote: `$ git remote add origin bing@bing.git` 식의 리모트 추가가 가능합니다.
- push: `$ git push origin master` 가 가능합니다.
- pull: `$ git pull origin master` 가 가능합니다.

## 화면 요소 변경
- `src/components/molecules/ProblemNavigator.vue`: 설정된 문제 갯수대로 표시되도록 수정
- `src/components/organisms/ProblemInstruction.vue`: 
  - `Problem` 클래스에 `content` 뿐만 아니라 `explanation` 필드 추가, 화면에서도 둘 다 출력되도록 조치
  - 명령어 말고 그냥 텍스트 강조표시를 위한 `*` 사용 처리